### PR TITLE
[feat] 출석 체크 기능 구현

### DIFF
--- a/Backend/src/main/java/com/github/backend/exception/AttendanceException.java
+++ b/Backend/src/main/java/com/github/backend/exception/AttendanceException.java
@@ -1,0 +1,17 @@
+package com.github.backend.exception;
+
+import com.github.backend.type.AttendanceErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AttendanceException extends RuntimeException {
+
+	private AttendanceErrorCode errorCode;
+	private String errorMessage;
+
+	public AttendanceException(AttendanceErrorCode errorCode) {
+		super(errorCode.getDescription());
+		this.errorCode = errorCode;
+		this.errorMessage = errorCode.getDescription();
+	}
+}

--- a/Backend/src/main/java/com/github/backend/persist/entity/Attendance.java
+++ b/Backend/src/main/java/com/github/backend/persist/entity/Attendance.java
@@ -1,0 +1,44 @@
+package com.github.backend.persist.entity;
+
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(uniqueConstraints = {
+	@UniqueConstraint(name = "attendanceCheck", columnNames = {"member_id", "attendanceDate"})
+}
+)
+@Entity
+public class Attendance extends BaseTimeEntity{
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn
+	private Member member;
+
+	private LocalDate attendanceDate;
+
+
+}

--- a/Backend/src/main/java/com/github/backend/persist/entity/Member.java
+++ b/Backend/src/main/java/com/github/backend/persist/entity/Member.java
@@ -40,5 +40,7 @@ public class Member extends BaseTimeEntity{
 	private Role role;
 
 
-
+	public void increasePoint(long amount) {
+		this.point += amount;
+	}
 }

--- a/Backend/src/main/java/com/github/backend/persist/repository/AttendanceRepository.java
+++ b/Backend/src/main/java/com/github/backend/persist/repository/AttendanceRepository.java
@@ -1,0 +1,12 @@
+package com.github.backend.persist.repository;
+
+import com.github.backend.persist.entity.Attendance;
+import com.github.backend.persist.entity.Member;
+import java.time.LocalDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+	boolean existsByMemberAndAttendanceDate(Member member,LocalDate date);
+
+}

--- a/Backend/src/main/java/com/github/backend/persist/repository/MemberRepository.java
+++ b/Backend/src/main/java/com/github/backend/persist/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.github.backend.persist.repository;
+
+import com.github.backend.persist.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByEmail(String email);
+
+}

--- a/Backend/src/main/java/com/github/backend/service/AttendanceService.java
+++ b/Backend/src/main/java/com/github/backend/service/AttendanceService.java
@@ -1,0 +1,8 @@
+package com.github.backend.service;
+
+public interface AttendanceService {
+
+	void checkTodayAttendance(String email);
+
+
+}

--- a/Backend/src/main/java/com/github/backend/service/impl/AttendanceServiceImpl.java
+++ b/Backend/src/main/java/com/github/backend/service/impl/AttendanceServiceImpl.java
@@ -1,0 +1,46 @@
+package com.github.backend.service.impl;
+
+import static com.github.backend.type.AttendanceErrorCode.*;
+
+import com.github.backend.exception.AttendanceException;
+import com.github.backend.persist.entity.Attendance;
+import com.github.backend.persist.entity.Member;
+import com.github.backend.persist.repository.AttendanceRepository;
+import com.github.backend.persist.repository.MemberRepository;
+import com.github.backend.service.AttendanceService;
+import com.github.backend.type.AttendanceErrorCode;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class AttendanceServiceImpl implements AttendanceService {
+
+	private final AttendanceRepository attendanceRepository;
+	private final MemberRepository memberRepository;
+
+	private static final long DAILY_ATTENDANCE_POINT = 50;
+
+	@Transactional
+	@Override
+	public void checkTodayAttendance(String email) {
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new AttendanceException(MEMBER_NOT_EXISTS));
+
+		LocalDate today = LocalDate.now();
+
+		if (attendanceRepository.existsByMemberAndAttendanceDate(member,today)) {
+			throw new AttendanceException(ALREADY_CHECK_ATTENDANCE);
+		}
+
+		member.increasePoint(DAILY_ATTENDANCE_POINT);
+
+		attendanceRepository.save(Attendance.builder()
+			.member(member)
+			.attendanceDate(today)
+			.build());
+	}
+}

--- a/Backend/src/main/java/com/github/backend/type/AttendanceErrorCode.java
+++ b/Backend/src/main/java/com/github/backend/type/AttendanceErrorCode.java
@@ -1,0 +1,13 @@
+package com.github.backend.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AttendanceErrorCode {
+	ALREADY_CHECK_ATTENDANCE("이미 출석체크를 완료하였습니다."),
+	MEMBER_NOT_EXISTS("존재하지 않는 회원입니다.");
+
+	private final String description;
+}

--- a/Backend/src/test/java/com/github/backend/service/impl/AttendanceServiceImplTest.java
+++ b/Backend/src/test/java/com/github/backend/service/impl/AttendanceServiceImplTest.java
@@ -1,0 +1,98 @@
+package com.github.backend.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.github.backend.exception.AttendanceException;
+import com.github.backend.persist.entity.Attendance;
+import com.github.backend.persist.entity.Member;
+import com.github.backend.persist.repository.AttendanceRepository;
+import com.github.backend.persist.repository.MemberRepository;
+import com.github.backend.type.AttendanceErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+class AttendanceServiceImplTest {
+
+	@Mock
+	AttendanceRepository attendanceRepository;
+
+	@Mock
+	MemberRepository memberRepository;
+
+
+	@InjectMocks
+	AttendanceServiceImpl attendanceService;
+
+	@DisplayName("출석체크 성공")
+	@Test
+	void checkTodayAttendance_SUCCESS() {
+		//given
+		Member member = Member.builder()
+			.email("test@test.com")
+			.build();
+
+		given(memberRepository.findByEmail(anyString()))
+			.willReturn(Optional.of(member));
+
+		given(attendanceRepository.existsByMemberAndAttendanceDate(any(), any()))
+			.willReturn(false);
+
+		given(attendanceRepository.save(any()))
+			.willReturn(Attendance.builder()
+				.member(member).build());
+
+		ArgumentCaptor<Attendance> captor = ArgumentCaptor.forClass(
+			Attendance.class);
+
+		//when
+		attendanceService.checkTodayAttendance("test@test.com");
+
+		//then
+		verify(attendanceRepository).save(captor.capture());
+
+		assertThat(captor.getValue().getMember().getEmail()).isEqualTo(member.getEmail());
+		assertThat(captor.getValue().getMember().getPoint()).isEqualTo(
+			50);
+	}
+
+	@DisplayName("출석체크 실패 - 회원이 없는 경우")
+	@Test
+	void checkTodayAttendance_fail_MemberNotExists(){
+	    //given
+		given(memberRepository.findByEmail(anyString()))
+			.willReturn(Optional.empty());
+	    //when
+		//then
+		assertThatThrownBy(() -> attendanceService.checkTodayAttendance("test@test.com"))
+			.isInstanceOf(AttendanceException.class)
+			.hasMessage(AttendanceErrorCode.MEMBER_NOT_EXISTS.getDescription());
+	}
+
+	@DisplayName("출석체크 실패 - 이미 출석을 한 경우")
+	@Test
+	void checkTodayAttendance_fail_AlreadyCheckAttendance(){
+	    //given
+		given(memberRepository.findByEmail(any()))
+			.willReturn(Optional.of(Member.builder().build()));
+		given(attendanceRepository.existsByMemberAndAttendanceDate(any(),any()))
+			.willReturn(true);
+	    //when
+		//then
+		assertThatThrownBy(() -> attendanceService.checkTodayAttendance("test@test.com"))
+			.isInstanceOf(AttendanceException.class)
+			.hasMessage(AttendanceErrorCode.ALREADY_CHECK_ATTENDANCE.getDescription());
+	}
+}


### PR DESCRIPTION
## 출석체크 기능 구현

## Issue 🎵
Closes #12 

## Kinds ✅
- [x] Feature
- [ ] Bug Fix

## Description ✏
출석 체크 기능을 구현하였습니다.
출석 체크는 로그인한 유저의 이메일을 받아 해당 이메일이 회원인지 검증한 후, 금일의 출석이 이미 이루어졌는지 체크한 뒤 회원의 포인트를 증가한 후 출석체크를 완료합니다.

Controller는 따로 구현하지 않았습니다. 후에 시큐리티 기능 부분이 완성되야 구현할 수 있어서 그 때 마저 구현하도록 하겠습니다.

참고로 Member Entity 클래스에 포인트 추가를 위한 메소드를 추가하였습니다. 참고 부탁드립니다.

## Changes 🛠
### AS-IS
현재 코드

### TO-BE
변경 코드

## Check List 📝
- [x] 구현 기능 테스트


## To Reviewers 🙏
머지 실수로 인하여 다시 PR후 Merge 하도록 하겠습니다.
