### PR TITLE
[feat] 강의 구매 API 구현

### DIFF
--- a/Backend/src/main/java/com/github/backend/model/dto/MemberCourseDto.java
+++ b/Backend/src/main/java/com/github/backend/model/dto/MemberCourseDto.java
@@ -1,0 +1,19 @@
+package com.github.backend.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class MemberCourseDto {
+
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	@Data
+	public static class TakeRequest {
+		private Long courseId;
+	}
+
+
+}

--- a/Backend/src/main/java/com/github/backend/service/MemberCourseService.java
+++ b/Backend/src/main/java/com/github/backend/service/MemberCourseService.java
@@ -2,7 +2,7 @@ package com.github.backend.service;
 
 public interface MemberCourseService {
 
-	void takeCourse(String email, Long courseId);
+	void takeCourse(Long memberId, Long courseId);
 
 	void toggleBookmark(String email, Long memberCourseId);
 }

--- a/Backend/src/main/java/com/github/backend/service/impl/MemberCourseServiceImpl.java
+++ b/Backend/src/main/java/com/github/backend/service/impl/MemberCourseServiceImpl.java
@@ -28,9 +28,9 @@ public class MemberCourseServiceImpl implements MemberCourseService {
 
 	@Transactional
 	@Override
-	public void takeCourse(String email, Long courseId) {
+	public void takeCourse(Long memberId, Long courseId) {
 
-		Member member = memberRepository.findByEmail(email)
+		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new MemberCourseException(MEMBER_NOT_EXISTS));
 
 		Course course = courseRepository.findById(courseId)

--- a/Backend/src/main/java/com/github/backend/web/MemberCourseController.java
+++ b/Backend/src/main/java/com/github/backend/web/MemberCourseController.java
@@ -1,0 +1,35 @@
+package com.github.backend.web;
+
+import static com.github.backend.model.dto.MemberCourseDto.TakeRequest;
+
+import com.github.backend.model.Result;
+import com.github.backend.model.dto.TokenMemberDto.MemberInfo;
+import com.github.backend.service.MemberCourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/member")
+@RestController
+public class MemberCourseController {
+
+	private final MemberCourseService memberCourseService;
+
+	@PostMapping("/course")
+	public ResponseEntity<Result<?>> takeCourse(
+		@AuthenticationPrincipal MemberInfo memberInfo,
+		@RequestBody TakeRequest request) {
+
+		memberCourseService.takeCourse(memberInfo.getId(), request.getCourseId());
+
+		return ResponseEntity.ok().body(new Result<>(200, true, ""));
+	}
+
+
+
+}

--- a/Backend/src/test/java/com/github/backend/service/impl/MemberCourseServiceImplTest.java
+++ b/Backend/src/test/java/com/github/backend/service/impl/MemberCourseServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -45,8 +44,9 @@ class MemberCourseServiceImplTest {
 	Course course;
 
 	@BeforeEach
-	void beforeAll() {
+	void beforeEach() {
 		member = Member.builder()
+			.id(1L)
 			.email("test@test.com")
 			.point(500)
 			.build();
@@ -62,7 +62,7 @@ class MemberCourseServiceImplTest {
 	@Test
 	void takeCourse_success() {
 		//given
-		given(memberRepository.findByEmail(anyString()))
+		given(memberRepository.findById(anyLong()))
 			.willReturn(Optional.of(member));
 
 		given(courseRepository.findById(anyLong()))
@@ -72,7 +72,7 @@ class MemberCourseServiceImplTest {
 			MemberCourse.class);
 
 		//when
-		memberCourseService.takeCourse(member.getEmail(), course.getId());
+		memberCourseService.takeCourse(member.getId(), course.getId());
 
 		//then
 		verify(memberCourseRepository).save(captor.capture());
@@ -84,13 +84,13 @@ class MemberCourseServiceImplTest {
 	@Test
 	void takeCourse_fail_MemberNotExists() {
 		//given
-		given(memberRepository.findByEmail(anyString()))
+		given(memberRepository.findById(anyLong()))
 			.willReturn(Optional.empty());
 		//when
 
 		//then
 		assertThatThrownBy(
-			() -> memberCourseService.takeCourse(member.getEmail(), course.getId()))
+			() -> memberCourseService.takeCourse(member.getId(), course.getId()))
 			.isInstanceOf(MemberCourseException.class)
 			.hasMessage(MemberCourseErrorCode.MEMBER_NOT_EXISTS.getDescription());
 	}
@@ -99,7 +99,7 @@ class MemberCourseServiceImplTest {
 	@Test
 	void takeCourse_fail_CourseNotExists() {
 		//given
-		given(memberRepository.findByEmail(anyString()))
+		given(memberRepository.findById(anyLong()))
 			.willReturn(Optional.of(member));
 
 		given(courseRepository.findById(anyLong()))
@@ -107,7 +107,7 @@ class MemberCourseServiceImplTest {
 		//when
 		//then
 		assertThatThrownBy(
-			() -> memberCourseService.takeCourse(member.getEmail(), course.getId()))
+			() -> memberCourseService.takeCourse(member.getId(), course.getId()))
 			.isInstanceOf(MemberCourseException.class)
 			.hasMessage(MemberCourseErrorCode.COURSE_NOT_EXISTS.getDescription());
 	}
@@ -116,7 +116,7 @@ class MemberCourseServiceImplTest {
 	@Test
 	void takeCourse_fail_AlreadyMemberCourseExists() {
 		//given
-		given(memberRepository.findByEmail(anyString()))
+		given(memberRepository.findById(anyLong()))
 			.willReturn(Optional.of(member));
 
 		given(courseRepository.findById(anyLong()))
@@ -128,7 +128,7 @@ class MemberCourseServiceImplTest {
 		//when
 		//then
 		assertThatThrownBy(
-			() -> memberCourseService.takeCourse(member.getEmail(), course.getId()))
+			() -> memberCourseService.takeCourse(member.getId(), course.getId()))
 			.isInstanceOf(MemberCourseException.class)
 			.hasMessage(MemberCourseErrorCode.ALREADY_MEMBER_COURSE_EXISTS.getDescription());
 	}
@@ -137,7 +137,7 @@ class MemberCourseServiceImplTest {
 	@Test
 	void takeCourse_fail_NotEnoughPoint() {
 		//given
-		given(memberRepository.findByEmail(anyString()))
+		given(memberRepository.findById(anyLong()))
 			.willReturn(Optional.of(member));
 
 		given(courseRepository.findById(anyLong()))
@@ -151,7 +151,7 @@ class MemberCourseServiceImplTest {
 		//when
 		//then
 		assertThatThrownBy(
-			() -> memberCourseService.takeCourse(member.getEmail(), course.getId()))
+			() -> memberCourseService.takeCourse(member.getId(), course.getId()))
 			.isInstanceOf(MemberCourseException.class)
 			.hasMessage(MemberCourseErrorCode.NOT_ENOUGH_POINT.getDescription());
 	}

--- a/Backend/src/test/java/com/github/backend/web/MemberCourseControllerTest.java
+++ b/Backend/src/test/java/com/github/backend/web/MemberCourseControllerTest.java
@@ -1,0 +1,71 @@
+package com.github.backend.web;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.backend.config.SecurityConfig;
+import com.github.backend.model.dto.MemberCourseDto.TakeRequest;
+import com.github.backend.security.jwt.JwtAuthenticationProvider;
+import com.github.backend.security.jwt.JwtEntryPoint;
+import com.github.backend.security.oauth.OAuth2SuccessHandler;
+import com.github.backend.service.MemberCourseService;
+import com.github.backend.service.impl.CustomOAuth2UserService;
+import com.github.backend.testUtils.WithMemberInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(value = MemberCourseController.class
+	, includeFilters = {
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+class MemberCourseControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@MockBean
+	JwtAuthenticationProvider jwtAuthenticationProvider;
+	@MockBean
+	JwtEntryPoint jwtEntryPoint;
+	@MockBean
+	OAuth2SuccessHandler oAuth2SuccessHandler;
+	@MockBean
+	CustomOAuth2UserService customOAuth2UserService;
+
+	@MockBean
+	MemberCourseService memberCourseService;
+
+	@WithMemberInfo
+	@DisplayName("강의 구매 성공")
+	@Test
+	void takeCourse_success() throws Exception {
+		//given
+		doNothing().when(memberCourseService).takeCourse(anyLong(), anyLong());
+
+		TakeRequest request = TakeRequest.builder()
+			.courseId(1L)
+			.build();
+
+		//when
+		//then
+		mockMvc.perform(post("/member/course")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.status").value(200));
+	}
+}


### PR DESCRIPTION
## 강의 구매 API 구현

## Issue 🎵
  
Closes #56 

## Kinds ✅
- [x] Feature
- [ ] Bug Fix

## Description ✏
강의 구매 API 구현하였습니다.

## Changes 🛠
### AS-IS
강의 구매 Service 기능만 구현

### TO-BE
강의 구매 Controller에 API 작성

## Check List 📝
- [x] 구현 기능 테스트


## To Reviewers 🙏
DTO 이름을 TakeMemberCourse의 Request , Response로 하면 좋을지, 아니면 PR 올린 것 처럼 MemberCourseDto의 TakeRequest가 좋을지 팀원분들의 의견이 궁금합니다.
