### PR TITLE
[feat] 공통 에러 처리 양식 추가

### DIFF
--- a/Backend/src/main/java/com/github/backend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/github/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,8 @@
+package com.github.backend.exception;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+}

--- a/Backend/src/main/java/com/github/backend/model/ErrorResult.java
+++ b/Backend/src/main/java/com/github/backend/model/ErrorResult.java
@@ -1,0 +1,17 @@
+package com.github.backend.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class ErrorResult {
+
+	private String errorCode;
+	private String errorDescription;
+
+}


### PR DESCRIPTION
## 공통 에러 처리 양식 추가

## Issue 🎵
  
Closes #70 

## Kinds ✅
- [x] Feature
- [ ] Bug Fix

## Description ✏
공통 에러 처리를 위한 양식을 추가하였습니다.
예외 처리 시, GlobalExceptionHandler class 에 @ExceptionHandler를 추가하여 예외처리 해주시면 됩니다.
응답 값으로는 ErrorResult의 builder를 이용하여 ResponseEntity.status(HttpStatuse 설정).body(ErrorResult 객체); 형식으로 반환하면 될 것 같습니다.

## Changes 🛠
### AS-IS
기존 예외 처리 응답에 대한 공통적인 양식이 없었습니다.

### TO-BE
공통 양식을 추가하여 에러 응답을 보내야할 시 GlobalExceptionHandler로 예외 응답을 보내도록 변경되었습니다.

## Check List 📝
- [ ] 구현 기능 테스트


## To Reviewers 🙏
변경사항이 필요하거나 추가할 기능, 의견 제시가 있다면 편하게 말씀해주세요