### PR TITLE
[feat] 토큰 재발급 API 추가

### DIFF
--- a/Backend/src/main/java/com/github/backend/web/common/AuthController.java
+++ b/Backend/src/main/java/com/github/backend/web/common/AuthController.java
@@ -3,18 +3,25 @@ package com.github.backend.web.common;
 import com.github.backend.dto.common.MemberInfo;
 import com.github.backend.dto.common.Result;
 import com.github.backend.persist.common.repository.RefreshTokenRepository;
+import com.github.backend.security.jwt.JwtInfo;
+import com.github.backend.security.jwt.TokenService;
+import com.github.backend.security.jwt.Tokens;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
-public class TokenController {
-   final RefreshTokenRepository refreshTokenRepository;
+public class AuthController {
+   private final RefreshTokenRepository refreshTokenRepository;
+   private final TokenService tokenService;
 
     @GetMapping("/logout")
     public ResponseEntity<Result<?>> logout(@AuthenticationPrincipal MemberInfo memberInfo){
@@ -28,4 +35,20 @@ public class TokenController {
                         .build()
         );
     }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Result<?>> reissueToken(@RequestBody String refreshToken){
+
+        Tokens token = tokenService.refresh(refreshToken);
+
+        return ResponseEntity.ok().body(
+                Result.builder()
+                        .status(200)
+                        .success(true)
+                        .data(token)
+                        .build()
+        );
+    }
+
+
 }


### PR DESCRIPTION
## 토큰 재발급 API 추가

## Issue 🎵
  
Closes #42 

## Kinds ✅
- [x] Feature
- [ ] Bug Fix

## Description ✏
Refresh 토큰을 통한 토큰 재발급 기능을 추가하였습니다.
Access Token이 만료되고 Refresh Token만 살아있을 경우 이용하면 됩니다.

## Changes 🛠
### AS-IS
현재 코드

### TO-BE
변경 코드

## Check List 📝
- [x] 구현 기능 테스트
- ! 부득이하게 테스트 코드는 작성하지 못했습니다. 실제로 작동하는지 Swagger를 통해 테스트 하였고, 후에 리팩토링 때 테스트 올리도록 하겠습니다.


## To Reviewers 🙏

