### PR TITLE
[feat] 내 강의, 출석, 토큰 재발급 API Swagger 추가 및 Swagger Config 수정

### DIFF
--- a/Backend/src/main/java/com/github/backend/config/SwaggerConfig.java
+++ b/Backend/src/main/java/com/github/backend/config/SwaggerConfig.java
@@ -1,12 +1,18 @@
 package com.github.backend.config;
 
+import com.fasterxml.classmate.TypeResolver;
+import com.github.backend.dto.common.MyPageable;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.AlternateTypeRules;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.ApiKey;
 import springfox.documentation.service.AuthorizationScope;
@@ -21,8 +27,11 @@ public class SwaggerConfig {
 	@Bean
 	public Docket api() {
 		return new Docket(DocumentationType.OAS_30)
+			.alternateTypeRules(
+				AlternateTypeRules.newRule(typeResolver.resolve(Pageable.class),
+					typeResolver.resolve(MyPageable.class))
+			)
 			.useDefaultResponseMessages(true)
-			.securityContexts(Arrays.asList(securityContext()))
 			.securitySchemes(Arrays.asList(apiKey()))
 			.apiInfo(apiInfo())
 			.select()
@@ -43,14 +52,6 @@ public class SwaggerConfig {
 		return new ApiKey("Authorization", "Authorization", "header");
 	}
 
-	private SecurityContext securityContext() {
-		return SecurityContext.builder().securityReferences(defaultAuth()).build();
-	}
+	private TypeResolver typeResolver = new TypeResolver();
 
-	private List<SecurityReference> defaultAuth() {
-		AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
-		AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
-		authorizationScopes[0] = authorizationScope;
-		return Arrays.asList(new SecurityReference("Authorization", authorizationScopes));
-	}
 }

--- a/Backend/src/main/java/com/github/backend/dto/attendance/AttendanceDto.java
+++ b/Backend/src/main/java/com/github/backend/dto/attendance/AttendanceDto.java
@@ -2,11 +2,14 @@ package com.github.backend.dto.attendance;
 
 import com.github.backend.persist.attendance.Attendance;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import springfox.documentation.annotations.ApiIgnore;
 
 
 public class AttendanceDto {
@@ -31,12 +34,12 @@ public class AttendanceDto {
 	@NoArgsConstructor
 	@Data
 	public static class GetRequest{
+
 		@ApiParam(hidden = true)
 		private Long memberId;
 
-		@ApiParam(value = "시작 날짜",defaultValue = "2022-08-01")
 		private LocalDate startDate;
-		@ApiParam(value = "종료 날짜",example = "2022-08-31")
+
 		private LocalDate endDate;
 	}
 

--- a/Backend/src/main/java/com/github/backend/dto/common/MyPageable.java
+++ b/Backend/src/main/java/com/github/backend/dto/common/MyPageable.java
@@ -1,0 +1,17 @@
+package com.github.backend.dto.common;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+@ApiModel
+public class MyPageable {
+
+	@ApiModelProperty(value = "페이지 번호(0~N), default = 0")
+	private int page;
+
+	@ApiModelProperty(value = "페이지 크기, default = 10")
+	private int size;
+
+}

--- a/Backend/src/main/java/com/github/backend/dto/myCourse/MyCourseSearchDto.java
+++ b/Backend/src/main/java/com/github/backend/dto/myCourse/MyCourseSearchDto.java
@@ -1,6 +1,7 @@
 package com.github.backend.dto.myCourse;
 
 import com.github.backend.persist.myCourse.repository.querydsl.cond.MyCourseSearchCond;
+import io.swagger.annotations.ApiParam;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,10 +15,18 @@ public class MyCourseSearchDto {
 	@Data
 	public static class Request {
 
+		@ApiParam(hidden = true)
 		private Long memberId;
+
+		@ApiParam(value = "강의 제목")
 		private String title;
+
+		@ApiParam(value = "게이머 닉네임")
 		private String gamerNickname;
+		@ApiParam(value = "게이머 이름")
 		private String gamerName;
+
+		@ApiParam(value = "즐겨찾기 여부")
 		private boolean bookmark;
 
 		public MyCourseSearchCond toCond() {

--- a/Backend/src/main/java/com/github/backend/persist/myCourse/repository/querydsl/MyCourseSearchRepository.java
+++ b/Backend/src/main/java/com/github/backend/persist/myCourse/repository/querydsl/MyCourseSearchRepository.java
@@ -42,6 +42,7 @@ public class MyCourseSearchRepository {
 				gamerNameLike(cond.getGamerName()),
 				bookmarkEq(cond.isBookmark())
 			)
+			.orderBy(course.createdDate.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();

--- a/Backend/src/main/java/com/github/backend/web/common/AuthController.java
+++ b/Backend/src/main/java/com/github/backend/web/common/AuthController.java
@@ -7,6 +7,9 @@ import com.github.backend.security.jwt.JwtInfo;
 import com.github.backend.security.jwt.TokenService;
 import com.github.backend.security.jwt.Tokens;
 import io.jsonwebtoken.Claims;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,8 +39,12 @@ public class AuthController {
         );
     }
 
+    @Operation(
+        summary = "토큰 재발급", description = "토큰을 재발급합니다. refresh Token값을 보내주세요"
+    )
     @PostMapping("/refresh")
-    public ResponseEntity<Result<?>> reissueToken(@RequestBody String refreshToken){
+    public ResponseEntity<Result<?>> reissueToken(
+         @RequestBody String refreshToken){
 
         Tokens token = tokenService.refresh(refreshToken);
 

--- a/Backend/src/main/java/com/github/backend/web/member/controller/AttendanceController.java
+++ b/Backend/src/main/java/com/github/backend/web/member/controller/AttendanceController.java
@@ -7,6 +7,14 @@ import com.github.backend.dto.common.Result;
 import com.github.backend.service.attendance.AttendanceService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,36 +24,40 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
+@Tag(name = "attendance",description = "내 출석 관련 API")
 @RequiredArgsConstructor
 @RestController
 public class AttendanceController {
 
 	private final AttendanceService attendanceService;
 
-	@ApiOperation(
-		value = "출석 체크하기",
-		notes = "출석 체크 시 50 포인트 추가 , 출석체크는 하루에 한번만 가능 , 로그인 필요"
+	@Operation(
+		summary = "출석 체크", description = "하루에 한번 출석 체크. 출석 체크시 포인트 증가",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"attendance"}
 	)
-
 	@PostMapping("/members/me/attendances/daily")
-	public ResponseEntity<Result<?>> checkDailyAttendance(@ApiIgnore @AuthenticationPrincipal MemberInfo memberInfo) {
+	public ResponseEntity<Result<?>> checkDailyAttendance(
+		@ApiIgnore @AuthenticationPrincipal MemberInfo memberInfo) {
 		attendanceService.checkTodayAttendance(memberInfo.getEmail());
-		return ResponseEntity.ok().body(new Result<>(200,true,""));
+		return ResponseEntity.ok().body(new Result<>(200, true, ""));
 	}
 
-	@ApiOperation(
-		value = "출석 조회",
-		notes = "원하는 기간만큼의 출석 조회 가능"
+	@Operation(
+		summary = "출석 조회", description = "원하는 기간만큼의 출석 조회 가능" ,
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"attendance"}
 	)
 	@GetMapping("/members/me/attendances")
-	public ResponseEntity<Result<?>> getAttendances(@ApiIgnore @AuthenticationPrincipal MemberInfo memberInfo,
+	public ResponseEntity<Result<?>> getAttendances(
+		@ApiIgnore @AuthenticationPrincipal MemberInfo memberInfo,
 		AttendanceDto.GetRequest request) {
 
 		request.setMemberId(memberInfo.getId());
 
 		List<Info> attendances = attendanceService.getAttendances(request);
 
-		return ResponseEntity.ok().body(new Result<>(200, true,attendances));
+		return ResponseEntity.ok().body(new Result<>(200, true, attendances));
 	}
 
 

--- a/Backend/src/main/java/com/github/backend/web/myCourse/controller/CourseUnlockController.java
+++ b/Backend/src/main/java/com/github/backend/web/myCourse/controller/CourseUnlockController.java
@@ -3,6 +3,10 @@ package com.github.backend.web.myCourse.controller;
 import com.github.backend.dto.common.MemberInfo;
 import com.github.backend.dto.common.Result;
 import com.github.backend.service.myCourse.MyCourseUnlockService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,14 +15,21 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
+@Tag(name = "myCourse",description = "내 강의 관련 API")
 @RequiredArgsConstructor
 @RestController
 public class CourseUnlockController {
 
 	private final MyCourseUnlockService myCourseUnlockService;
 
+	@Operation(
+		summary = "강의 해금", description = "강의를 해금합니다.",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"myCourse"}
+	)
 	@PostMapping("/courses/{courseId}/unlock")
-	public ResponseEntity<Result<?>> unlockCourse(@ApiIgnore  @AuthenticationPrincipal MemberInfo memberInfo, @PathVariable Long courseId) {
+	public ResponseEntity<Result<?>> unlockCourse(@ApiIgnore @AuthenticationPrincipal MemberInfo memberInfo,
+		@Parameter(description = "강의 Id") @PathVariable Long courseId) {
 
 		myCourseUnlockService.unlockCourse(memberInfo.getId(),courseId);
 

--- a/Backend/src/main/java/com/github/backend/web/myCourse/controller/MyCoursePageController.java
+++ b/Backend/src/main/java/com/github/backend/web/myCourse/controller/MyCoursePageController.java
@@ -7,9 +7,18 @@ import com.github.backend.dto.myCourse.MyCourseSearchDto.Info;
 import com.github.backend.dto.myCourse.MyCourseSearchDto.Request;
 import com.github.backend.service.myCourse.MyCourseBookmarkService;
 import com.github.backend.service.myCourse.MyCourseInfoSearchService;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
+@Tag(name = "myCourse", description = "내 강의 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/members/me/courses")
 @RestController
@@ -27,11 +37,19 @@ public class MyCoursePageController {
 	private final MyCourseInfoSearchService myCourseInfoSearchService;
 	private final MyCourseBookmarkService myCourseBookmarkService;
 
+	@Operation(
+		summary = "내 강의 조회", description = "해금한 강의를 조회합니다.",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"myCourse"}
+	)
 	@GetMapping
-	public ResponseEntity<Result<?>> searchMyCourse(@ApiIgnore  @AuthenticationPrincipal MemberInfo memberInfo,
-		Pageable pageable, Request request) {
+	public ResponseEntity<Result<?>> searchMyCourse(
+		@ApiIgnore @AuthenticationPrincipal MemberInfo memberInfo,
+		@PageableDefault(size = 10, page = 0) Pageable pageable, Request request) {
+
 		request.setMemberId(memberInfo.getId());
 		Page<Info> infos = myCourseInfoSearchService.searchMyCourses(pageable, request);
+
 		return ResponseEntity.ok().body(Result.builder()
 			.status(200)
 			.success(true)
@@ -39,9 +57,15 @@ public class MyCoursePageController {
 			.build());
 	}
 
+	@Operation(
+		summary = "내 강의 즐겨찾기", description = "해금한 강의를 즐겨찾기합니다.",
+		security = {@SecurityRequirement(name = "Authorization")},
+		tags = {"myCourse"}
+	)
 	@PostMapping("/{courseId}/bookmark")
-	public ResponseEntity<Result<?>> toggleBookmark(@ApiIgnore @AuthenticationPrincipal MemberInfo memberInfo,
-		@PathVariable Long courseId) {
+	public ResponseEntity<Result<?>> toggleBookmark(
+		@ApiIgnore @AuthenticationPrincipal MemberInfo memberInfo,
+		@Parameter(description = "강의 Id")@PathVariable Long courseId) {
 
 		boolean bookmark
 			= myCourseBookmarkService.toggleBookmark(memberInfo.getId(), courseId);


### PR DESCRIPTION
## 내 강의, 출석, 토큰 재발급 API Swagger 추가

## Issue 🎵
  
 #113 

## Kinds ✅
- [x] Feature
- [ ] Bug Fix

## Description ✏
- 내 강의, 출석, 토큰 재발급 API Swagger 추가했습니다.
- JWT 인증이 필요한 API만 Header에 토큰을 날릴 수 있도록 설정했습니다.


## Changes 🛠
### AS-IS
- 기본 스웨거 문서 설정
- JWT를 넣으면 모든 API에 헤더를 보냈음

### TO-BE
- 스웨거 문서에 한글로 정리
- JWT가 필요한 API만 따로 표시할 수 있도록 설정

## Check List 📝
- [x] 구현 기능 테스트

## To Reviewers 🙏
추가적인 사항이 있다면 말씀해주세요
