### PR TITLE
[feat] 내 강의 조회 API

### DIFF
--- a/Backend/src/main/java/com/github/backend/service/course/impl/CourseService.java
+++ b/Backend/src/main/java/com/github/backend/service/course/impl/CourseService.java
@@ -3,10 +3,14 @@ package com.github.backend.service.course.impl;
 import com.github.backend.dto.course.CourseInfoOutputDto;
 import com.github.backend.dto.course.SearchCourse;
 import com.github.backend.exception.course.CourseException;
+import com.github.backend.exception.myCourse.MyCourseException;
+import com.github.backend.exception.myCourse.code.MyCourseErrorCode;
 import com.github.backend.persist.course.Course;
 import com.github.backend.persist.course.repository.CourseRepository;
 import com.github.backend.exception.course.code.CourseErrorCode;
 import com.github.backend.persist.course.repository.querydsl.CourseSearchRepository;
+import com.github.backend.persist.myCourse.MyCourse;
+import com.github.backend.persist.myCourse.repository.MyCourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,14 +23,23 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class CourseService {
+
     private final CourseSearchRepository courseSearchRepository;
+    private final MyCourseRepository myCourseRepository;
 
-
-    @Transactional
-    public Page<CourseInfoOutputDto.Info> searchCourseList(SearchCourse searchCourse, Pageable pageable){
+    @Transactional(readOnly = true)
+    public Page<CourseInfoOutputDto.Info> searchCourseList(SearchCourse searchCourse,
+        Pageable pageable) {
 
         return courseSearchRepository.searchByWhere(searchCourse.toCondition(), pageable)
-                .map(CourseInfoOutputDto.Info::of);
+            .map(CourseInfoOutputDto.Info::of);
     }
 
+    @Transactional(readOnly = true)
+    public CourseInfoOutputDto.Info searchMyCourse(Long memberId, Long courseId) {
+        MyCourse myCourse = myCourseRepository.findByMember_IdAndCourse_Id(memberId, courseId)
+            .orElseThrow(() -> new MyCourseException(MyCourseErrorCode.MY_COURSE_NOT_EXISTS));
+
+        return CourseInfoOutputDto.Info.of(myCourse.getCourse());
+    }
 }

--- a/Backend/src/main/java/com/github/backend/web/course/controller/CourseController.java
+++ b/Backend/src/main/java/com/github/backend/web/course/controller/CourseController.java
@@ -6,6 +6,9 @@ import com.github.backend.dto.course.CourseInfoOutputDto;
 import com.github.backend.dto.course.CourseInfoOutputDto.Info;
 import com.github.backend.dto.course.SearchCourse;
 import com.github.backend.service.course.impl.CourseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Course")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/courses")
@@ -26,6 +30,10 @@ public class CourseController {
 
     private final CourseService courseService;
 
+    @Operation(
+        summary = "강의 전체 조회", description = "강의를 전체 조회 합니다.",
+        tags = {"Course"}
+    )
     @GetMapping
     public ResponseEntity<Result<?>> getCourseList(SearchCourse searchCourse, Pageable pageable) {
 
@@ -41,6 +49,11 @@ public class CourseController {
         );
     }
 
+    @Operation(
+        summary = "강의 조회", description = "강의를 조회합니다. 로그인 회원 및 구매한 강의만 조회 가능합니다.",
+        security = {@SecurityRequirement(name = "Authorization")},
+        tags = {"Course"}
+    )
     @GetMapping("/{courseId}")
     public ResponseEntity<Result<?>> getMyCourse(@AuthenticationPrincipal MemberInfo memberInfo, @PathVariable Long courseId) {
         Info info = courseService.searchMyCourse(memberInfo.getId(), courseId);

--- a/Backend/src/main/java/com/github/backend/web/course/controller/CourseController.java
+++ b/Backend/src/main/java/com/github/backend/web/course/controller/CourseController.java
@@ -1,7 +1,9 @@
 package com.github.backend.web.course.controller;
 
+import com.github.backend.dto.common.MemberInfo;
 import com.github.backend.dto.common.Result;
 import com.github.backend.dto.course.CourseInfoOutputDto;
+import com.github.backend.dto.course.CourseInfoOutputDto.Info;
 import com.github.backend.dto.course.SearchCourse;
 import com.github.backend.service.course.impl.CourseService;
 import javax.validation.Valid;
@@ -9,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,24 +21,36 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/course")
+@RequestMapping("/courses")
 public class CourseController {
 
     private final CourseService courseService;
 
-    @GetMapping("/courses")
-    public ResponseEntity<Result<?>> getCourseList(SearchCourse searchCourse, Pageable pageable){
+    @GetMapping
+    public ResponseEntity<Result<?>> getCourseList(SearchCourse searchCourse, Pageable pageable) {
 
-        Page<CourseInfoOutputDto.Info> courseList = courseService.searchCourseList(searchCourse, pageable);
+        Page<CourseInfoOutputDto.Info> courseList = courseService.searchCourseList(searchCourse,
+            pageable);
 
         return ResponseEntity.ok().body(
-                Result.builder()
-                        .status(200)
-                        .success(true)
-                        .data(courseList)
-                        .build()
+            Result.builder()
+                .status(200)
+                .success(true)
+                .data(courseList)
+                .build()
         );
     }
 
+    @GetMapping("/{courseId}")
+    public ResponseEntity<Result<?>> getMyCourse(@AuthenticationPrincipal MemberInfo memberInfo, @PathVariable Long courseId) {
+        Info info = courseService.searchMyCourse(memberInfo.getId(), courseId);
 
+        return ResponseEntity.ok().body(
+            Result.builder()
+                .status(200)
+                .success(true)
+                .data(info)
+                .build()
+        );
+    }
 }

--- a/Backend/src/main/java/com/github/backend/web/member/controller/MyCourseController.java
+++ b/Backend/src/main/java/com/github/backend/web/member/controller/MyCourseController.java
@@ -36,7 +36,7 @@ public class MyCourseController {
 
 
 	@Operation(
-		summary = "내 강의 조회", description = "해금한 강의를 조회합니다.",
+		summary = "내 강의 전체 조회", description = "해금한 강의를 전체 조회합니다.",
 		security = {@SecurityRequirement(name = "Authorization")},
 		tags = {"My Course"}
 	)

--- a/Backend/src/test/java/com/github/backend/service/admin/CourseServiceTest.java
+++ b/Backend/src/test/java/com/github/backend/service/admin/CourseServiceTest.java
@@ -1,12 +1,16 @@
 package com.github.backend.service.admin;
 
 import com.github.backend.dto.course.CourseInfoOutputDto;
+import com.github.backend.dto.course.CourseInfoOutputDto.Info;
 import com.github.backend.dto.course.SearchCourse;
 import com.github.backend.persist.course.Course;
 import com.github.backend.persist.course.repository.querydsl.CourseSearchRepository;
 import com.github.backend.persist.gamer.Gamer;
 import com.github.backend.persist.course.repository.CourseRepository;
+import com.github.backend.persist.myCourse.MyCourse;
+import com.github.backend.persist.myCourse.repository.MyCourseRepository;
 import com.github.backend.service.course.impl.CourseService;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +22,7 @@ import org.springframework.data.domain.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -32,6 +37,9 @@ public class CourseServiceTest {
 
     @Mock
     private CourseSearchRepository courseSearchRepository;
+
+    @Mock
+    private MyCourseRepository myCourseRepository;
 
     @InjectMocks
     private CourseService courseService;
@@ -93,5 +101,35 @@ public class CourseServiceTest {
         assertEquals(courseList.getContent().get(1).getRace(), course2.getRace());
     }
 
+    @DisplayName("강의 조회 성공")
+    @Test
+    void searchMyCourse_success(){
+        //given
+        Course course = Course.builder()
+            .id(2L)
+            .gamer(Gamer.builder()
+                .id(1L)
+                .name("유영진")
+                .build())
+            .title("벙커링")
+            .price(10L)
+            .build();
+
+        MyCourse myCourse = MyCourse.builder()
+            .course(course)
+            .build();
+
+        given(myCourseRepository.findByMember_IdAndCourse_Id(anyLong(), any()))
+            .willReturn(Optional.of(myCourse));
+
+        //when
+        Info info = courseService.searchMyCourse(anyLong(), anyLong());
+
+        //then
+        assertThat(info.getId()).isEqualTo(course.getId());
+        assertThat(info.getTitle()).isEqualTo(course.getTitle());
+        assertThat(info.getPrice()).isEqualTo(course.getPrice());
+
+    }
 }
 

--- a/Backend/src/test/java/com/github/backend/web/course/controller/CourseControllerTest.java
+++ b/Backend/src/test/java/com/github/backend/web/course/controller/CourseControllerTest.java
@@ -3,14 +3,17 @@ package com.github.backend.web.course.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.backend.config.SecurityConfig;
 import com.github.backend.dto.course.CourseInfoOutputDto;
+import com.github.backend.dto.course.CourseInfoOutputDto.Info;
 import com.github.backend.persist.course.Course;
 import com.github.backend.persist.gamer.Gamer;
 import com.github.backend.security.jwt.JwtAccessDeniedHandler;
 import com.github.backend.security.jwt.JwtAuthenticationProvider;
 import com.github.backend.security.jwt.JwtEntryPoint;
 import com.github.backend.service.course.impl.CourseService;
+import com.github.backend.testUtils.WithMemberInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -24,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -110,5 +114,43 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.data.content[0].race").value(course.getRace()))
                 .andExpect(jsonPath("$.data.content[0].price").value(course.getPrice()))
                 .andExpect(status().isOk());
+    }
+
+    @WithMemberInfo
+    @DisplayName("강의 조회 성공")
+    @Test
+    void getMyCourse_success() throws Exception {
+
+        Info info = Info.builder()
+            .id(1L)
+            .gamerName("test")
+            .title("벙커링")
+            .videoUrl("https://www.youtube.com/watch?v=2rpu0f-qog4")
+            .thumbnailUrl("https://img.youtube.com/vi/2rpu0f-qog4/default.jpg")
+            .comment("세상에서 제일 쉬운 8배럭 벙커링 강의")
+            .level("입문")
+            .race("테란")
+            .price(10L)
+            .build();
+
+
+        //given
+        given(courseService.searchMyCourse(anyLong(), anyLong()))
+            .willReturn(info);
+
+        //when
+        //then
+        mockMvc.perform(get("/courses/1"))
+            .andDo(print())
+            .andExpect(jsonPath("$.data.title").value(info.getTitle()))
+            .andExpect(jsonPath("$.data.videoUrl").value(info.getVideoUrl()))
+            .andExpect(jsonPath("$.data.thumbnailUrl").value(info.getThumbnailUrl()))
+            .andExpect(jsonPath("$.data.comment").value(info.getComment()))
+            .andExpect(jsonPath("$.data.level").value(info.getLevel()))
+            .andExpect(jsonPath("$.data.race").value(info.getRace()))
+            .andExpect(jsonPath("$.data.price").value(info.getPrice()))
+            .andExpect(status().isOk());
+
+
     }
 }


### PR DESCRIPTION
## 내 강의 조회 API

## Issue 🎵
  
Closes #138 

## Kinds ✅
- [x] Feature
- [ ] Bug Fix

## Description ✏
내 강의 조회를 할 수 있는 API 를 작성했습니다.
로그인 후에 이용할 수 있으며 memberId와 courseId로 해당 강의를 회원이 가지고있는지 조회한 후, Course 정보를 반환합니다.
memberId같은 경우, API 요청 시에 들어오는 JWT를 파싱한 정보를 이용합니다. 

## Changes 🛠
### AS-IS
현재 코드

### TO-BE
변경 코드

## Check List 📝
- [x] 구현 기능 테스트


## To Reviewers 🙏

